### PR TITLE
Add reproducibility and reviewedness metrics support

### DIFF
--- a/src/core/url_processor.py
+++ b/src/core/url_processor.py
@@ -4,18 +4,21 @@ import sys
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 from urllib.parse import urlparse
 
-from src.metrics.base import ModelContext
+from src.metrics.base import ModelContext, MetricCalculator
 from src.metrics.busfactor_calculator import BusFactorCalculator
 from src.metrics.code_quality_calculator import CodeQualityCalculator
 from src.metrics.dataset_code_calculator import DatasetCodeCalculator
 from src.metrics.dataset_quality_calculator import DatasetQualityCalculator
 from src.metrics.license_calculator import LicenseCalculator
+from src.metrics.reproducibility_calculator import ReproducibilityCalculator
+from src.metrics.reviewedness_calculator import ReviewednessCalculator
 from src.metrics.performance_claims_calculator import \
     PerformanceClaimsCalculator
 from src.metrics.ramp_up_calculator import RampUpCalculator
+from src.metrics.tree_score_calculator import TreeScoreCalculator
 from src.metrics.size_calculator import SizeCalculator
 from src.storage.results_storage import (MetricResult, ModelResult,
                                          ResultsStorage)
@@ -352,7 +355,13 @@ class URLProcessor:
                 code_quality_score=0.0,
                 code_quality_latency=0,
                 performance_claims_score=0.0,
-                performance_claims_latency=0
+                performance_claims_latency=0,
+                reproducibility_score=0.0,
+                reproducibility_latency=0,
+                reviewedness_score=0.0,
+                reviewedness_latency=0,
+                tree_score=0.0,
+                tree_score_latency=0
             )
         except Exception as e:
             print(
@@ -379,7 +388,13 @@ class URLProcessor:
                 code_quality_score=0.0,
                 code_quality_latency=0,
                 performance_claims_score=0.0,
-                performance_claims_latency=0
+                performance_claims_latency=0,
+                reproducibility_score=0.0,
+                reproducibility_latency=0,
+                reviewedness_score=0.0,
+                reviewedness_latency=0,
+                tree_score=0.0,
+                tree_score_latency=0
             )
 
     def _create_model_context(
@@ -463,151 +478,103 @@ class URLProcessor:
         timestamp: str = datetime.datetime.now().isoformat()
         metrics: Dict[str, MetricResult] = {}
 
-        def calculate_license() -> Tuple[str, MetricResult]:
-            try:
-                calc = LicenseCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "License", MetricResult("License", score, latency, timestamp)
-            except Exception as e:
-                print(f"License calculation failed: {e}", file=sys.stderr)
-                return "License", MetricResult("License", 0.5, 100, timestamp)
+        metric_registry: Dict[str, Type[MetricCalculator]] = {
+            "License": LicenseCalculator,
+            "DatasetCode": DatasetCodeCalculator,
+            "DatasetQuality": DatasetQualityCalculator,
+            "BusFactor": BusFactorCalculator,
+            "Size": SizeCalculator,
+            "RampUp": RampUpCalculator,
+            "CodeQuality": CodeQualityCalculator,
+            "PerformanceClaims": PerformanceClaimsCalculator,
+            "Reproducibility": ReproducibilityCalculator,
+            "Reviewedness": ReviewednessCalculator,
+            "TreeScore": TreeScoreCalculator,
+        }
 
-        def calculate_dataset_code() -> Tuple[str, MetricResult]:
-            try:
-                calc = DatasetCodeCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "DatasetCode", MetricResult(
-                    "DatasetCode", score, latency, timestamp)
-            except Exception as e:
-                print(f"DatasetCode calculation failed: {e}", file=sys.stderr)
-                return "DatasetCode", MetricResult("DatasetCode", 0.5, 100, timestamp)
+        fallback_scores: Dict[str, Any] = {
+            "License": 0.5,
+            "DatasetCode": 0.5,
+            "DatasetQuality": 0.5,
+            "BusFactor": 0.5,
+            "Size": {
+                "raspberry_pi": 0.5,
+                "jetson_nano": 0.6,
+                "desktop_pc": 0.8,
+                "aws_server": 0.9
+            },
+            "RampUp": 0.7,
+            "CodeQuality": 0.9,
+            "PerformanceClaims": 0.8,
+            "Reproducibility": 0.5,
+            "Reviewedness": 0.5,
+            "TreeScore": 0.5,
+        }
 
-        def calculate_dataset_quality() -> Tuple[str, MetricResult]:
-            try:
-                calc = DatasetQualityCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "DatasetQuality", MetricResult(
-                    "DatasetQuality", score, latency, timestamp)
-            except Exception as e:
-                print(f"DatasetQuality calculation failed: {e}", file=sys.stderr)
-                return "DatasetQuality", MetricResult(
-                    "DatasetQuality", 0.5, 100, timestamp)
+        fallback_latencies: Dict[str, int] = {
+            "License": 100,
+            "DatasetCode": 100,
+            "DatasetQuality": 100,
+            "BusFactor": 100,
+            "Size": 100,
+            "RampUp": 200,
+            "CodeQuality": 180,
+            "PerformanceClaims": 220,
+            "Reproducibility": 160,
+            "Reviewedness": 170,
+            "TreeScore": 150,
+        }
 
-        def calculate_bus_factor() -> Tuple[str, MetricResult]:
-            try:
-                calc = BusFactorCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "BusFactor", MetricResult("BusFactor", score, latency, timestamp)
-            except Exception as e:
-                print(f"BusFactor calculation failed: {e}", file=sys.stderr)
-                return "BusFactor", MetricResult("BusFactor", 0.5, 100, timestamp)
-
-        def calculate_size() -> Tuple[str, MetricResult]:
-            try:
-                calc = SizeCalculator()
+        def execute_metric(metric_name: str,
+                           calculator_cls: Type[MetricCalculator]
+                           ) -> Tuple[str, MetricResult]:
+            calc = calculator_cls()
+            if metric_name == "Size":
                 calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                platform_scores = calc.get_platform_compatibility()
-                return "Size", MetricResult("Size", platform_scores, latency, timestamp)
-            except Exception as e:
-                print(f"Size calculation failed: {e}", file=sys.stderr)
-                return "Size", MetricResult("Size", {
-                    "raspberry_pi": 0.5, "jetson_nano": 0.6,
-                    "desktop_pc": 0.8, "aws_server": 0.9
-                }, 100, timestamp)
-
-        def calculate_ramp_up() -> Tuple[str, MetricResult]:
-            try:
-                calc = RampUpCalculator()
+                score = calc.get_platform_compatibility()
+            else:
                 score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "RampUp", MetricResult("RampUp", score, latency, timestamp)
-            except Exception as e:
-                print(f"RampUp calculation failed: {e}", file=sys.stderr)
-                return "RampUp", MetricResult("RampUp", 0.7, 200, timestamp)
+            latency = calc.get_calculation_time() or 0
+            return metric_name, MetricResult(metric_name, score, latency, timestamp)
 
-        def calculate_code_quality() -> Tuple[str, MetricResult]:
-            try:
-                calc = CodeQualityCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "CodeQuality", MetricResult(
-                    "CodeQuality", score, latency, timestamp)
-            except Exception as e:
-                print(f"CodeQuality calculation failed: {e}", file=sys.stderr)
-                return "CodeQuality", MetricResult("CodeQuality", 0.9, 180, timestamp)
-
-        def calculate_performance_claims() -> Tuple[str, MetricResult]:
-            try:
-                calc = PerformanceClaimsCalculator()
-                score = calc.calculate_score(model_context)
-                latency = calc.get_calculation_time() or 0
-                return "PerformanceClaims", MetricResult(
-                    "PerformanceClaims", score, latency, timestamp)
-            except Exception as e:
-                print(f"PerformanceClaims calculation failed: {e}", file=sys.stderr)
-                return "PerformanceClaims", MetricResult(
-                    "PerformanceClaims", 0.8, 220, timestamp)
-        metric_functions: List[Any] = [
-            calculate_license,
-            calculate_dataset_code,
-            calculate_dataset_quality,
-            calculate_bus_factor,
-            calculate_size,
-            calculate_ramp_up,
-            calculate_code_quality,
-            calculate_performance_claims
-        ]
-
-        import os
-        max_workers: int = min(4, os.cpu_count() or 2)
+        cpu_count = os.cpu_count() or 2
+        max_workers = min(len(metric_registry), max(4, cpu_count))
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-
             future_to_metric: Dict[Any, str] = {
-                executor.submit(func): func.__name__ for func in metric_functions
+                executor.submit(execute_metric, name, calculator): name
+                for name, calculator in metric_registry.items()
             }
+
             for future in as_completed(future_to_metric):
+                metric_name = future_to_metric[future]
                 try:
-                    metric_name, metric_result = future.result()
-                    metrics[metric_name] = metric_result
+                    metric_key, metric_result = future.result()
+                    metrics[metric_key] = metric_result
                 except Exception as e:
-                    metric_name = future_to_metric[future]
                     print(
                         f"Metric calculation {metric_name} failed: {e}",
                         file=sys.stderr)
-
-                    if metric_name == "calculate_size":
-                        default_sizes = {
-                            "raspberry_pi": 0.5, "jetson_nano": 0.6,
-                            "desktop_pc": 0.8, "aws_server": 0.9
-                        }
-                        metrics["Size"] = MetricResult(
-                            "Size", default_sizes, 100, timestamp)
-                    else:
-                        metrics[metric_name.replace("calculate_", "").title()] = (
-                            MetricResult(
-                                metric_name.replace("calculate_", "").title(),
-                                0.5, 100, timestamp
-                            ))
+                    fallback_score = fallback_scores.get(metric_name, 0.5)
+                    fallback_latency = fallback_latencies.get(metric_name, 150)
+                    metrics[metric_name] = MetricResult(
+                        metric_name, fallback_score, fallback_latency, timestamp)
 
         return metrics
 
     def _calculate_net_score(self, metrics: Dict[str, MetricResult]) -> float:
-        # Original plan weights: 0.20⋅L + 0.20⋅R + 0.15⋅B + 0.15⋅DAC + 0.10⋅DQ + 0.10⋅CQ + 0.05⋅P + 0.05⋅S
         weights: Dict[str, float] = {
-            "License": 0.20,        # L: License compatibility
-            "RampUp": 0.20,        # R: Ramp-up time
-            "BusFactor": 0.15,     # B: Bus factor
-            "DatasetCode": 0.15,   # DAC: Dataset and code availability
-            "DatasetQuality": 0.10, # DQ: Dataset quality
-            "CodeQuality": 0.10,   # CQ: Code quality
+            "License": 0.15,           # L: License compatibility
+            "RampUp": 0.15,            # R: Ramp-up time
+            "BusFactor": 0.10,         # B: Bus factor
+            "DatasetCode": 0.10,       # DAC: Dataset and code availability
+            "DatasetQuality": 0.10,    # DQ: Dataset quality
+            "CodeQuality": 0.10,       # CQ: Code quality
             "PerformanceClaims": 0.05, # P: Performance claims
-            "Size": 0.05           # S: Size compatibility
+            "Size": 0.05,              # S: Size compatibility
+            "Reproducibility": 0.10,   # New reproducibility metric
+            "Reviewedness": 0.05,      # Community reviewedness
+            "TreeScore": 0.05          # Repository tree structure
         }
 
         net_score: float = 0.0

--- a/src/metrics/reproducibility_calculator.py
+++ b/src/metrics/reproducibility_calculator.py
@@ -1,0 +1,54 @@
+"""Reproducibility metric calculator.
+
+This calculator provides a lightweight heuristic for estimating how easily a
+model can be reproduced based on the available context.  It considers whether
+code and datasets are provided as well as a few common Hugging Face metadata
+fields that typically document training and evaluation procedures.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+from .base import MetricCalculator, ModelContext
+
+
+class ReproducibilityCalculator(MetricCalculator):
+    """Estimate how reproducible a model is from the supplied context."""
+
+    def __init__(self) -> None:
+        super().__init__("Reproducibility")
+
+    def calculate_score(self, context: ModelContext) -> float:
+        start_time = time.perf_counter()
+
+        score = 0.4
+
+        if getattr(context, "code_url", None):
+            score += 0.2
+
+        if getattr(context, "dataset_url", None):
+            score += 0.2
+
+        metadata: Dict[str, Any] = {}
+        if isinstance(context.huggingface_metadata, dict):
+            metadata = context.huggingface_metadata
+
+        card_data = metadata.get("cardData") if isinstance(metadata, dict) else None
+        if isinstance(card_data, dict):
+            if card_data.get("training") or card_data.get("evaluation"):
+                score += 0.1
+            if card_data.get("datasets") or card_data.get("library_name"):
+                score += 0.05
+
+        model_index = metadata.get("model_index") if isinstance(metadata, dict) else None
+        if model_index:
+            score += 0.05
+
+        score = max(0.0, min(1.0, score))
+
+        elapsed_ms = int((time.perf_counter() - start_time) * 1000)
+        self._set_score(score, elapsed_ms)
+        return score
+

--- a/src/metrics/reviewedness_calculator.py
+++ b/src/metrics/reviewedness_calculator.py
@@ -1,0 +1,59 @@
+"""Reviewedness metric calculator.
+
+The reviewedness score is a heuristic indicator of how much community feedback
+or vetting a model has received.  It leverages lightweight signals such as
+likes/downloads on Hugging Face and repository statistics when present.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+from .base import MetricCalculator, ModelContext
+
+
+class ReviewednessCalculator(MetricCalculator):
+    """Provide an approximate measure of community review and feedback."""
+
+    def __init__(self) -> None:
+        super().__init__("Reviewedness")
+
+    def calculate_score(self, context: ModelContext) -> float:
+        start_time = time.perf_counter()
+
+        score = 0.2
+
+        metadata: Dict[str, Any] = {}
+        if isinstance(context.huggingface_metadata, dict):
+            metadata = context.huggingface_metadata
+
+        likes = 0
+        downloads = 0
+        if isinstance(metadata, dict):
+            likes = int(metadata.get("likes", 0) or 0)
+            downloads = int(metadata.get("downloads", 0) or 0)
+
+        score += min(likes / 2500.0, 0.4)
+        score += min(downloads / 4_000_000.0, 0.2)
+
+        if isinstance(metadata.get("cardData"), dict) and metadata["cardData"].get("annotations"):
+            score += 0.1
+
+        model_info = context.model_info if isinstance(context.model_info, dict) else {}
+        stars = int(model_info.get("stars", 0) or 0) if isinstance(model_info, dict) else 0
+        score += min(stars / 6000.0, 0.2)
+
+        if isinstance(model_info, dict) and model_info.get("github_metadata"):
+            gh_meta = model_info["github_metadata"]
+            if isinstance(gh_meta, dict):
+                open_issues = int(gh_meta.get("open_issues_count", 0) or 0)
+                if open_issues <= 5:
+                    score += 0.05
+
+        score = max(0.0, min(1.0, score))
+
+        elapsed_ms = int((time.perf_counter() - start_time) * 1000)
+        self._set_score(score, elapsed_ms)
+        return score
+

--- a/src/metrics/tree_score_calculator.py
+++ b/src/metrics/tree_score_calculator.py
@@ -1,0 +1,62 @@
+"""TreeScore metric calculator.
+
+TreeScore approximates how well structured a repository or model card is by
+inspecting available metadata.  The heuristic favours projects that expose
+rich directory trees (siblings on Hugging Face) and common documentation files.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Iterable
+
+from .base import MetricCalculator, ModelContext
+
+
+class TreeScoreCalculator(MetricCalculator):
+    """Heuristic scoring for repository/tree structure quality."""
+
+    def __init__(self) -> None:
+        super().__init__("TreeScore")
+
+    def calculate_score(self, context: ModelContext) -> float:
+        start_time = time.perf_counter()
+
+        score = 0.3
+
+        metadata: Dict[str, Any] = {}
+        if isinstance(context.huggingface_metadata, dict):
+            metadata = context.huggingface_metadata
+
+        siblings = metadata.get("siblings") if isinstance(metadata, dict) else None
+        if isinstance(siblings, Iterable):
+            sibling_names = [self._get_sibling_name(s) for s in siblings]
+            if sibling_names:
+                score += min(len(sibling_names) / 20.0, 0.3)
+                if any(name.lower().startswith("readme") for name in sibling_names if name):
+                    score += 0.1
+                if any(name.lower().endswith(('.py', '.ipynb')) for name in sibling_names if name):
+                    score += 0.1
+
+        model_info = context.model_info if isinstance(context.model_info, dict) else {}
+        if isinstance(model_info, dict):
+            if model_info.get("local_repo_path"):
+                score += 0.05
+            if model_info.get("files") and isinstance(model_info["files"], list):
+                score += min(len(model_info["files"]) / 50.0, 0.1)
+
+        if getattr(context, "code_url", None):
+            score += 0.05
+
+        score = max(0.0, min(1.0, score))
+
+        elapsed_ms = int((time.perf_counter() - start_time) * 1000)
+        self._set_score(score, elapsed_ms)
+        return score
+
+    @staticmethod
+    def _get_sibling_name(sibling: Any) -> str:
+        if isinstance(sibling, dict):
+            return str(sibling.get("rfilename") or sibling.get("filename") or "")
+        return str(getattr(sibling, "rfilename", "") or "")
+

--- a/src/storage/results_storage.py
+++ b/src/storage/results_storage.py
@@ -36,6 +36,12 @@ class ModelResult:
     code_quality_latency: int
     performance_claims_score: float
     performance_claims_latency: int
+    reproducibility_score: float
+    reproducibility_latency: int
+    reviewedness_score: float
+    reviewedness_latency: int
+    tree_score: float
+    tree_score_latency: int
 
     def _extract_model_name(self) -> str:
         try:
@@ -72,6 +78,9 @@ class ModelResult:
         dataset_code_val = self._format_decimal(self.dataset_code_score)
         dataset_quality_val = self._format_decimal(self.dataset_quality_score)
         code_quality_val = self._format_decimal(self.code_quality_score)
+        reproducibility_val = self._format_decimal(self.reproducibility_score)
+        reviewedness_val = self._format_decimal(self.reviewedness_score)
+        tree_score_val = self._format_decimal(self.tree_score)
 
         size_score_dict = {}
         if isinstance(self.size_score, dict):
@@ -124,7 +133,13 @@ class ModelResult:
             "dataset_quality": dataset_quality_val,
             "dataset_quality_latency": self.dataset_quality_latency,
             "code_quality": code_quality_val,
-            "code_quality_latency": self.code_quality_latency
+            "code_quality_latency": self.code_quality_latency,
+            "reproducibility": reproducibility_val,
+            "reproducibility_latency": self.reproducibility_latency,
+            "reviewedness": reviewedness_val,
+            "reviewedness_latency": self.reviewedness_latency,
+            "tree_score": tree_score_val,
+            "tree_score_latency": self.tree_score_latency
         }
         return json.dumps(result_dict, separators=(',', ':'), cls=DecimalEncoder)
 
@@ -152,7 +167,8 @@ class ResultsStorage:
     def is_model_complete(self, model_url: str) -> bool:
         required_metrics = {
             "Size", "License", "RampUp", "BusFactor",
-            "DatasetCode", "DatasetQuality", "CodeQuality", "PerformanceClaims"
+            "DatasetCode", "DatasetQuality", "CodeQuality",
+            "PerformanceClaims", "Reproducibility", "Reviewedness", "TreeScore"
         }
 
         model_metrics = set(self._model_results.get(model_url, {}).keys())
@@ -200,7 +216,13 @@ class ResultsStorage:
             code_quality_score=metrics["CodeQuality"].score,
             code_quality_latency=metrics["CodeQuality"].calculation_time_ms,
             performance_claims_score=metrics["PerformanceClaims"].score,
-            performance_claims_latency=metrics["PerformanceClaims"].calculation_time_ms
+            performance_claims_latency=metrics["PerformanceClaims"].calculation_time_ms,
+            reproducibility_score=metrics["Reproducibility"].score,
+            reproducibility_latency=metrics["Reproducibility"].calculation_time_ms,
+            reviewedness_score=metrics["Reviewedness"].score,
+            reviewedness_latency=metrics["Reviewedness"].calculation_time_ms,
+            tree_score=metrics["TreeScore"].score,
+            tree_score_latency=metrics["TreeScore"].calculation_time_ms
         )
 
         self._completed_models.append(model_result)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -384,6 +384,9 @@ class TestURLProcessorMethods(unittest.TestCase):
         self.assertEqual(result.license_score, 0.0)
         self.assertEqual(result.ramp_up_score, 0.0)
         self.assertEqual(result.bus_factor_score, 0.0)
+        self.assertEqual(result.reproducibility_score, 0.0)
+        self.assertEqual(result.reviewedness_score, 0.0)
+        self.assertEqual(result.tree_score, 0.0)
     
     def test_calculate_net_score(self):
         processor = URLProcessor("test.txt")
@@ -396,12 +399,18 @@ class TestURLProcessorMethods(unittest.TestCase):
             "DatasetQuality": MetricResult("DatasetQuality", 0.6, 180, "2023-01-01"),
             "CodeQuality": MetricResult("CodeQuality", 0.85, 160, "2023-01-01"),
             "PerformanceClaims": MetricResult("PerformanceClaims", 0.75, 140, "2023-01-01"),
-            "Size": MetricResult("Size", {"raspberry_pi": 0.3, "jetson_nano": 0.5, "desktop_pc": 0.9, "aws_server": 1.0}, 90, "2023-01-01")
+            "Size": MetricResult("Size", {"raspberry_pi": 0.3, "jetson_nano": 0.5, "desktop_pc": 0.9, "aws_server": 1.0}, 90, "2023-01-01"),
+            "Reproducibility": MetricResult("Reproducibility", 0.65, 110, "2023-01-01"),
+            "Reviewedness": MetricResult("Reviewedness", 0.55, 130, "2023-01-01"),
+            "TreeScore": MetricResult("TreeScore", 0.6, 90, "2023-01-01")
         }
-        
+
         net_score = processor._calculate_net_score(metrics)
-        
-        expected = 0.20*1.0 + 0.20*0.8 + 0.15*0.7 + 0.15*0.9 + 0.10*0.6 + 0.10*0.85 + 0.05*0.75 + 0.05*1.0
+
+        expected = (
+            0.15*1.0 + 0.15*0.8 + 0.10*0.7 + 0.10*0.9 + 0.10*0.6 + 0.10*0.85 +
+            0.05*0.75 + 0.05*1.0 + 0.10*0.65 + 0.05*0.55 + 0.05*0.6
+        )
         self.assertEqual(net_score, round(expected, 2))
     
     def test_infer_datasets_from_context(self):
@@ -518,7 +527,7 @@ class TestURLProcessorMethods(unittest.TestCase):
             "RampUp": MetricResult("RampUp", 0.8, 200, "2023-01-01")
         }
         net_score = processor._calculate_net_score(metrics)
-        expected = 0.20*1.0 + 0.20*0.8  # Only these two metrics
+        expected = 0.15*1.0 + 0.15*0.8  # Only these two metrics
         self.assertEqual(net_score, round(expected, 2))
 
     def test_calculate_net_score_with_invalid_size_metric(self):
@@ -531,7 +540,7 @@ class TestURLProcessorMethods(unittest.TestCase):
             "Size": MetricResult("Size", 0.0, 90, "2023-01-01")  
         }
         net_score = processor._calculate_net_score(metrics)
-        expected = 0.20*1.0 + 0.30*0.0  # License + Size
+        expected = 0.15*1.0 + 0.05*0.0  # License + Size
         self.assertEqual(net_score, round(expected, 2))
 
     @patch('builtins.open', new_callable=mock_open, read_data="https://huggingface.co/test/model")
@@ -643,7 +652,10 @@ class TestURLProcessorMethods(unittest.TestCase):
             "DatasetQuality": MetricResult("DatasetQuality", 0.6, 180, "2023-01-01"),
             "CodeQuality": MetricResult("CodeQuality", 0.85, 160, "2023-01-01"),
             "PerformanceClaims": MetricResult("PerformanceClaims", 0.75, 140, "2023-01-01"),
-            "Size": MetricResult("Size", {"raspberry_pi": 0.3, "jetson_nano": 0.5, "desktop_pc": 0.9, "aws_server": 1.0}, 90, "2023-01-01")
+            "Size": MetricResult("Size", {"raspberry_pi": 0.3, "jetson_nano": 0.5, "desktop_pc": 0.9, "aws_server": 1.0}, 90, "2023-01-01"),
+            "Reproducibility": MetricResult("Reproducibility", 0.7, 100, "2023-01-01"),
+            "Reviewedness": MetricResult("Reviewedness", 0.65, 110, "2023-01-01"),
+            "TreeScore": MetricResult("TreeScore", 0.6, 95, "2023-01-01")
         }
         mock_metrics.return_value = metrics
         
@@ -915,7 +927,13 @@ class TestModelResult(unittest.TestCase):
             code_quality_score=0.8,
             code_quality_latency=35,
             performance_claims_score=0.75,
-            performance_claims_latency=45
+            performance_claims_latency=45,
+            reproducibility_score=0.5,
+            reproducibility_latency=55,
+            reviewedness_score=0.45,
+            reviewedness_latency=60,
+            tree_score=0.62,
+            tree_score_latency=65
         )
         self.assertEqual(result.url, "https://huggingface.co/test_model")
         self.assertEqual(result._extract_model_name(), "test_model")
@@ -940,13 +958,22 @@ class TestModelResult(unittest.TestCase):
             code_quality_score=0.6,
             code_quality_latency=45,
             performance_claims_score=0.75,
-            performance_claims_latency=40
+            performance_claims_latency=40,
+            reproducibility_score=0.55,
+            reproducibility_latency=50,
+            reviewedness_score=0.6,
+            reviewedness_latency=45,
+            tree_score=0.58,
+            tree_score_latency=55
         )
-        
+
         ndjson_line = result.to_ndjson_line()
         self.assertIsInstance(ndjson_line, str)
         self.assertIn("test_model", ndjson_line)
         self.assertIn("net_score", ndjson_line)
+        self.assertIn("\"reproducibility\":0.55", ndjson_line)
+        self.assertIn("\"reviewedness\":0.60", ndjson_line)
+        self.assertIn("\"tree_score\":0.58", ndjson_line)
 
 
 class TestLLMClient(unittest.TestCase):
@@ -5330,7 +5357,10 @@ class TestResultsStorageComprehensive(unittest.TestCase):
                 dataset_code_score=0.8, dataset_code_latency=100,
                 dataset_quality_score=0.7, dataset_quality_latency=150,
                 code_quality_score=0.9, code_quality_latency=200,
-                performance_claims_score=0.6, performance_claims_latency=250
+                performance_claims_score=0.6, performance_claims_latency=250,
+                reproducibility_score=0.65, reproducibility_latency=210,
+                reviewedness_score=0.55, reviewedness_latency=220,
+                tree_score=0.5, tree_score_latency=230
             )
         
         # Test HuggingFace URL with no path parts (line 50)
@@ -5367,7 +5397,7 @@ class TestResultsStorageComprehensive(unittest.TestCase):
     def test_to_ndjson_line_with_none_size_score(self):
         """Test to_ndjson_line when size_score is None (line 89)."""
         from src.storage.results_storage import ModelResult
-        
+
         # Create ModelResult with None size_score (line 89)
         result = ModelResult(
             url="https://example.com/test", net_score=0.8, net_score_latency=100,
@@ -5378,7 +5408,10 @@ class TestResultsStorageComprehensive(unittest.TestCase):
             dataset_code_score=0.8, dataset_code_latency=100,
             dataset_quality_score=0.7, dataset_quality_latency=150,
             code_quality_score=0.9, code_quality_latency=200,
-            performance_claims_score=0.6, performance_claims_latency=250
+            performance_claims_score=0.6, performance_claims_latency=250,
+            reproducibility_score=0.5, reproducibility_latency=210,
+            reviewedness_score=0.45, reviewedness_latency=220,
+            tree_score=0.52, tree_score_latency=230
         )
         
         ndjson_line = result.to_ndjson_line()
@@ -5386,6 +5419,69 @@ class TestResultsStorageComprehensive(unittest.TestCase):
         # Should hit line 89: the else branch for size_score handling
         self.assertIn('"raspberry_pi":0.0', ndjson_line)
         self.assertIn('"jetson_nano":0.0', ndjson_line)
+
+
+    def test_is_model_complete_requires_new_metrics(self):
+        """Ensure all metrics, including the new ones, are required."""
+        from src.storage.results_storage import ResultsStorage
+
+        storage = ResultsStorage()
+        url = "https://example.com/model"
+        timestamp = "2023-01-01"
+
+        metrics_data = {
+            "Size": ({"raspberry_pi": 0.8, "jetson_nano": 0.9, "desktop_pc": 1.0, "aws_server": 1.0}, 90),
+            "License": (0.9, 80),
+            "RampUp": (0.85, 70),
+            "BusFactor": (0.75, 65),
+            "DatasetCode": (0.8, 75),
+            "DatasetQuality": (0.7, 85),
+            "CodeQuality": (0.88, 95),
+            "PerformanceClaims": (0.76, 90),
+            "Reproducibility": (0.8, 88),
+            "Reviewedness": (0.6, 92),
+        }
+
+        for name, (score, latency) in metrics_data.items():
+            storage.store_metric_result(url, MetricResult(name, score, latency, timestamp))
+
+        self.assertFalse(storage.is_model_complete(url))
+
+        storage.store_metric_result(url, MetricResult("TreeScore", 0.7, 85, timestamp))
+
+        self.assertTrue(storage.is_model_complete(url))
+
+    def test_finalize_model_result_includes_new_metrics(self):
+        """Regression test that serialization includes the expanded metrics set."""
+        from src.storage.results_storage import ResultsStorage
+
+        storage = ResultsStorage()
+        url = "https://example.com/model"
+        timestamp = "2023-01-01"
+
+        metrics_data = {
+            "Size": ({"raspberry_pi": 0.9, "jetson_nano": 0.95, "desktop_pc": 1.0, "aws_server": 1.0}, 100),
+            "License": (0.92, 80),
+            "RampUp": (0.81, 70),
+            "BusFactor": (0.7, 65),
+            "DatasetCode": (0.78, 75),
+            "DatasetQuality": (0.74, 85),
+            "CodeQuality": (0.83, 90),
+            "PerformanceClaims": (0.77, 95),
+            "Reproducibility": (0.82, 88),
+            "Reviewedness": (0.66, 92),
+            "TreeScore": (0.69, 86),
+        }
+
+        for name, (score, latency) in metrics_data.items():
+            storage.store_metric_result(url, MetricResult(name, score, latency, timestamp))
+
+        result = storage.finalize_model_result(url, 0.84, 215)
+        ndjson_line = result.to_ndjson_line()
+
+        self.assertIn('"reproducibility":0.82', ndjson_line)
+        self.assertIn('"reviewedness":0.66', ndjson_line)
+        self.assertIn('"tree_score":0.69', ndjson_line)
 
 
 class TestSizeCalculator(unittest.TestCase):


### PR DESCRIPTION
## Summary
- instantiate the new reproducibility, reviewedness, and tree score calculators in the URL processor metric registry and rebalance the net score weights
- extend ResultsStorage and ModelResult to persist the additional metrics, update default results, and serialize the expanded fields
- update the unit test suite to reflect the new scoring weights and add regression coverage for the added metrics

## Testing
- pytest tests/test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68f84be3a12c832e879a3bfae8be8691