### PR TITLE
Add placeholder model rating route invoking Run pipeline

### DIFF
--- a/app/src/pipelines/RunPipeline.js
+++ b/app/src/pipelines/RunPipeline.js
@@ -1,7 +1,47 @@
-//This will be the abstraction for the Run executable / our phase 1 project
+// app/src/pipelines/RunPipeline.js
+// Abstraction over the Run executable / Phase 1 project integration point
 
 class RunPipeline {
-    async executeRun(params) {}
+  async executeRun(params = {}) {
+    console.log("RunPipeline accessed", params);
+
+    const { id } = params;
+
+    // Return a placeholder model rating object that matches the OpenAPI schema
+    return {
+      name: `model-${id ?? "unknown"}`,
+      category: "baseline",
+      net_score: 0,
+      net_score_latency: 0,
+      ramp_up_time: 0,
+      ramp_up_time_latency: 0,
+      bus_factor: 0,
+      bus_factor_latency: 0,
+      performance_claims: 0,
+      performance_claims_latency: 0,
+      license: 0,
+      license_latency: 0,
+      dataset_and_code_score: 0,
+      dataset_and_code_score_latency: 0,
+      dataset_quality: 0,
+      dataset_quality_latency: 0,
+      code_quality: 0,
+      code_quality_latency: 0,
+      reproducibility: 0,
+      reproducibility_latency: 0,
+      reviewedness: 0,
+      reviewedness_latency: 0,
+      tree_score: 0,
+      tree_score_latency: 0,
+      size_score: {
+        raspberry_pi: 0,
+        jetson_nano: 0,
+        desktop_pc: 0,
+        aws_server: 0,
+      },
+      size_score_latency: 0,
+    };
+  }
 }
 
 export default RunPipeline;

--- a/app/src/routes/rate.js
+++ b/app/src/routes/rate.js
@@ -1,1 +1,30 @@
-//the rate route
+// app/src/routes/rate.js
+// Handles model rating retrieval requests
+import express from "express";
+import RunPipeline from "../pipelines/RunPipeline.js";
+
+const router = express.Router();
+const pipeline = new RunPipeline();
+
+// GET /artifact/model/:id/rate
+router.get("/:id/rate", async (req, res) => {
+  const { id } = req.params || {};
+  if (!id) {
+    return res.status(400).json({ error: "model id is required" });
+  }
+
+  const authToken = req.header("X-Authorization");
+  if (!authToken) {
+    return res.status(403).json({ error: "missing authentication token" });
+  }
+
+  try {
+    const rating = await pipeline.executeRun({ id, authToken });
+    return res.status(200).json(rating);
+  } catch (error) {
+    console.error("Failed to retrieve rating:", error);
+    return res.status(500).json({ error: "failed to retrieve rating" });
+  }
+});
+
+export default router;

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -3,6 +3,7 @@ import "dotenv/config";
 import express from "express";
 import uploadRouter from "./routes/upload.js";
 import downloadRouter from "./routes/download.js";
+import rateRouter from "./routes/rate.js";
 
 const app = express();
 
@@ -12,6 +13,7 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 
 app.use("/upload", uploadRouter);
 app.use("/download", downloadRouter);
+app.use("/artifact/model", rateRouter);
 
 const port = process.env.PORT || 3100;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add a model rating route that calls the Run pipeline abstraction and returns a placeholder rating response
- stub the Run pipeline to log access and supply the OpenAPI-compliant rating payload
- register the new route in the Express server

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68fd5e6931a0832e8252ca02e8a238a4